### PR TITLE
Clarity fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import (
 
 // Create the default GQLGen server
 exec := handler.NewDefaultServer(
-	server.NewExecutableSchema(
+    server.NewExecutableSchema(
         server.Config{Resolvers: resolvers},
     ),
 )

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import (
 exec := handler.NewDefaultServer(
 	server.NewExecutableSchema(
         server.Config{Resolvers: resolvers},
-	),
+    ),
 )
 
 // Use as a GQLGen plugin

--- a/README.md
+++ b/README.md
@@ -2,14 +2,27 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ec2-software/gqlgen-introspect-filter.svg)](https://pkg.go.dev/github.com/ec2-software/gqlgen-introspect-filter)
 
-Filter GQLGen's Introspection by your application's business logic.
+Filter GQLGen's Introspection Schema using your application's business logic.
 
 ```go
+
+import (
+    "github.com/99designs/gqlgen/graphql/handler"
+    "yourprojectname/generated/server"
+)
+
+// Create the default GQLGen server
+exec := handler.NewDefaultServer(
+	server.NewExecutableSchema(
+        server.Config{Resolvers: resolvers},
+	),
+)
+
 // Use as a GQLGen plugin
 exec.Use(introspectionfilter.Plugin{
-	Schema:      schema,
-	
 	// Write filter functions to choose if various parts are included.
-	FieldFilter: func(fd *ast.FieldDefinition) bool { return fd.Name != "text" },
+	ReturnField: func(ctx context.Context, fd *ast.FieldDefinition, d *ast.Definition) bool { 
+		return fd.Name != "text" 
+	},
 })
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ exec := handler.NewDefaultServer(
 )
 
 // Use as a GQLGen plugin
-exec.Use(introspectionfilter.Plugin{
+exec.Use(introspectionfilter.Extension{
 	// Write filter functions to choose if various parts are included.
 	ReturnField: func(ctx context.Context, fd *ast.FieldDefinition, d *ast.Definition) bool { 
 		return fd.Name != "text" 

--- a/introspection_filter_test.go
+++ b/introspection_filter_test.go
@@ -23,8 +23,8 @@ func TestPlugin(t *testing.T) {
 		graphql.GetOperationContext(ctx).DisableIntrospection = false
 		return next(ctx)
 	})
-	exec.Use(&introspectionfilter.Plugin{
-		FieldFilter: func(ctx context.Context, fd *ast.FieldDefinition) bool { return fd.Name != "text" },
+	exec.Use(&introspectionfilter.Extension{
+		ReturnField: func(ctx context.Context, fd *ast.FieldDefinition, d *ast.Definition) bool { return fd.Name != "text" },
 	})
 	ctx := context.Background()
 


### PR DESCRIPTION
- Renamed "Plugin" to "Extension", because they're two different things in GQLgen
- Fixed the interface, the Extension shouldn't have methods with a pointer receiver according to the interface definition
- Rename the struct fields for Extension/Plugin -> The intention is now clearer. Does FilterField == true return the field or remove it? It's now ReturnField, which is easier to read.
- Updated the example code to give extra context
- Added type definition as third parameter to the FieldFilter, because you might want to return a field based on the parent type